### PR TITLE
Pico all compat

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -71,6 +71,5 @@ target_sources(${PROJECT} PUBLIC
 			target_link_libraries(${PROJECT} PUBLIC pico_cyw43_arch_none hardware_clocks)
 		endif()
 
-        # Configure compilation flags and libraries for the example... see the corresponding function
-        # in hw/bsp/FAMILY/family.cmake for details.
-        # family_configure_device_example(${PROJECT}) // Not needed?
+		pico_add_extra_outputs(${PROJECT})
+

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -26,6 +26,7 @@ target_sources(${PROJECT} PUBLIC
         ${CMAKE_CURRENT_SOURCE_DIR}/src/cert.c
         ${CMAKE_CURRENT_SOURCE_DIR}/src/u2f.c
         ${CMAKE_CURRENT_SOURCE_DIR}/src/led.c
+        ${CMAKE_CURRENT_SOURCE_DIR}/src/presence.c
         ${CMAKE_CURRENT_SOURCE_DIR}/src/usb_descriptors.c
         ${CMAKE_CURRENT_SOURCE_DIR}/lib/wolfssl/wolfcrypt/src/asn.c
         ${CMAKE_CURRENT_SOURCE_DIR}/lib/wolfssl/wolfcrypt/src/wc_port.c

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -67,6 +67,7 @@ target_sources(${PROJECT} PUBLIC
 			message("It's a Pico W.....")
 			target_link_libraries(${PROJECT} PUBLIC pico_cyw43_arch_none hardware_clocks)
 		endif()
- for the example... see the corresponding function
-# in hw/bsp/FAMILY/family.cmake for details.
-family_configure_device_example(${PROJECT})
+
+        # Configure compilation flags and libraries for the example... see the corresponding function
+        # in hw/bsp/FAMILY/family.cmake for details.
+        family_configure_device_example(${PROJECT})

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -25,6 +25,7 @@ target_sources(${PROJECT} PUBLIC
         ${CMAKE_CURRENT_SOURCE_DIR}/src/rand.c
         ${CMAKE_CURRENT_SOURCE_DIR}/src/cert.c
         ${CMAKE_CURRENT_SOURCE_DIR}/src/u2f.c
+        ${CMAKE_CURRENT_SOURCE_DIR}/src/led.c
         ${CMAKE_CURRENT_SOURCE_DIR}/src/usb_descriptors.c
         ${CMAKE_CURRENT_SOURCE_DIR}/lib/wolfssl/wolfcrypt/src/asn.c
         ${CMAKE_CURRENT_SOURCE_DIR}/lib/wolfssl/wolfcrypt/src/wc_port.c
@@ -46,13 +47,14 @@ target_sources(${PROJECT} PUBLIC
         ${CMAKE_CURRENT_SOURCE_DIR}/lib/wolfssl/wolfcrypt/src/sp_c32.c
         )
 
-# Example include
-target_include_directories(${PROJECT} PUBLIC
+        # Example include
+        target_include_directories(${PROJECT} PUBLIC
         ${CMAKE_CURRENT_SOURCE_DIR}/src 
         ${CMAKE_CURRENT_SOURCE_DIR}/lib/wolfssl
         )
 
-        target_compile_definitions( ${PROJECT} PUBLIC WOLFSSL_USER_SETTINGS)
+        target_compile_definitions(${PROJECT} PUBLIC WOLFSSL_USER_SETTINGS)
+        target_compile_definitions(${PROJECT} PRIVATE CYW43_PIO_CLOCK_DIV_DYNAMIC=1)
 
 
         target_link_libraries(${PROJECT} PUBLIC pico_stdlib)
@@ -60,6 +62,11 @@ target_include_directories(${PROJECT} PUBLIC
         target_link_libraries(${PROJECT} PUBLIC hardware_adc)
         target_link_libraries(${PROJECT} PUBLIC hardware_flash)
 
-# Configure compilation flags and libraries for the example... see the corresponding function
+		# Configure compilation flags and libraries# Cater for Pico W
+		if (PICO_CYW43_SUPPORTED)
+			message("It's a Pico W.....")
+			target_link_libraries(${PROJECT} PUBLIC pico_cyw43_arch_none hardware_clocks)
+		endif()
+ for the example... see the corresponding function
 # in hw/bsp/FAMILY/family.cmake for details.
 family_configure_device_example(${PROJECT})

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -61,7 +61,10 @@ target_sources(${PROJECT} PUBLIC
         target_link_libraries(${PROJECT} PUBLIC pico_multicore)
         target_link_libraries(${PROJECT} PUBLIC hardware_adc)
         target_link_libraries(${PROJECT} PUBLIC hardware_flash)
-
+        target_link_libraries(${PROJECT} PUBLIC pico_unique_id)
+        target_link_libraries(${PROJECT} PUBLIC tinyusb_device) 
+        target_link_libraries(${PROJECT} PUBLIC tinyusb_board)
+		
 		# Configure compilation flags and libraries# Cater for Pico W
 		if (PICO_CYW43_SUPPORTED)
 			message("It's a Pico W.....")
@@ -70,4 +73,4 @@ target_sources(${PROJECT} PUBLIC
 
         # Configure compilation flags and libraries for the example... see the corresponding function
         # in hw/bsp/FAMILY/family.cmake for details.
-        family_configure_device_example(${PROJECT})
+        # family_configure_device_example(${PROJECT}) // Not needed?

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -57,6 +57,7 @@ target_sources(${PROJECT} PUBLIC
         target_compile_definitions(${PROJECT} PUBLIC WOLFSSL_USER_SETTINGS)
         target_compile_definitions(${PROJECT} PRIVATE CYW43_PIO_CLOCK_DIV_DYNAMIC=1)
 
+		# target_compile_definitions(${PROJECT} PUBLIC USE_BOOTSEL_BUTTON)
 
         target_link_libraries(${PROJECT} PUBLIC pico_stdlib)
         target_link_libraries(${PROJECT} PUBLIC pico_multicore)

--- a/VSCode.CMakeLists.txt
+++ b/VSCode.CMakeLists.txt
@@ -1,0 +1,105 @@
+# Generated Cmake Pico project file
+
+cmake_minimum_required(VERSION 3.13)
+
+set(CMAKE_C_STANDARD 11)
+set(CMAKE_CXX_STANDARD 17)
+set(CMAKE_EXPORT_COMPILE_COMMANDS ON)
+
+# set(FAMILY rp2350)
+
+# Initialise pico_sdk from installed location
+# (note this can come from environment, CMake cache etc)
+
+# == DO NEVER EDIT THE NEXT LINES for Raspberry Pi Pico VS Code Extension to work ==
+if(WIN32)
+    set(USERHOME $ENV{USERPROFILE})
+else()
+    set(USERHOME $ENV{HOME})
+endif()
+set(sdkVersion 2.0.0)
+set(toolchainVersion 13_2_Rel1)
+set(picotoolVersion 2.0.0)
+include(${USERHOME}/.pico-sdk/cmake/pico-vscode.cmake)
+# ====================================================================================
+set(PICO_BOARD pico_w CACHE STRING "Board type")
+
+# Pull in Raspberry Pi Pico SDK (must be before project)
+include(pico_sdk_import.cmake)
+# include($ENV{PICO_SDK_PATH}/lib/tinyusb/hw/bsp/family_support.cmake)
+
+project(fidelio C CXX ASM)
+
+# Initialise the Raspberry Pi Pico SDK
+pico_sdk_init()
+
+# Add executable. Default name is the project name, version 0.1
+set(SOURCE_FILES 
+        src/fidelio.c 
+        src/rand.c 
+        src/led.c
+        src/presence.c
+        src/cert.c 
+        src/u2f.c 
+        src/usb_descriptors.c
+        
+        lib/wolfssl/wolfcrypt/src/asn.c
+        lib/wolfssl/wolfcrypt/src/wc_port.c
+        lib/wolfssl/wolfcrypt/src/wolfmath.c
+        lib/wolfssl/wolfcrypt/src/hash.c
+        lib/wolfssl/wolfcrypt/src/memory.c
+        lib/wolfssl/wolfcrypt/src/misc.c
+        lib/wolfssl/wolfcrypt/src/ecc.c
+        lib/wolfssl/wolfcrypt/src/hmac.c
+        lib/wolfssl/wolfcrypt/src/coding.c
+        lib/wolfssl/wolfcrypt/src/random.c
+        lib/wolfssl/wolfcrypt/src/sha256.c
+        lib/wolfssl/wolfcrypt/src/sha512.c
+        lib/wolfssl/wolfcrypt/src/ge_low_mem.c
+        lib/wolfssl/wolfcrypt/src/fe_low_mem.c
+        lib/wolfssl/wolfcrypt/src/ge_operations.c
+        lib/wolfssl/wolfcrypt/src/sp_int.c
+        lib/wolfssl/wolfcrypt/src/sp_armthumb.c
+        lib/wolfssl/wolfcrypt/src/sp_c32.c
+        )
+
+add_executable(fidelio ${SOURCE_FILES})
+
+pico_set_program_name(fidelio "Fidelio")
+pico_set_program_version(fidelio "0.1")
+
+# Modify the below lines to enable/disable output over UART/USB
+pico_enable_stdio_uart(fidelio 0)
+pico_enable_stdio_usb(fidelio 0)
+
+# Add the standard library to the build
+target_link_libraries(fidelio
+        pico_stdlib
+		pico_multicore
+		hardware_adc
+		hardware_flash
+        pico_unique_id 
+        tinyusb_device 
+        tinyusb_board
+        )
+
+# Cater for Pico W
+if (PICO_CYW43_SUPPORTED)
+    message("It's a Pico w.....")
+    target_link_libraries(fidelio pico_cyw43_arch_none hardware_clocks)
+endif()
+
+# Add the standard include files to the build
+target_include_directories(fidelio PRIVATE
+  ${CMAKE_CURRENT_SOURCE_DIR}/src
+  ${CMAKE_CURRENT_SOURCE_DIR}/lib/wolfssl
+)
+
+target_compile_definitions(fidelio PUBLIC WOLFSSL_USER_SETTINGS)
+# target_compile_definitions(fidelio PUBLIC USE_BOOTSEL_BUTTON)
+target_compile_definitions(fidelio PRIVATE CYW43_PIO_CLOCK_DIV_DYNAMIC=1)
+
+pico_add_extra_outputs(fidelio)
+
+message("End of CMakeLists.txt.....")
+

--- a/WINDOWS.md
+++ b/WINDOWS.md
@@ -39,7 +39,9 @@ Get the zip from https://sourceforge.net/projects/xxd-for-windows/ Use your favo
 To make sure the above utilities are installed correctly open a command prompt and enter the following commands....
 
 openssl -h
+
 sed -h
+
 xxd -h
 
 All three should display some usage information. If they don't then you've most likely not added them to your path correctly

--- a/WINDOWS.md
+++ b/WINDOWS.md
@@ -1,0 +1,58 @@
+### Windows Quirks
+
+While Fidelio can be compiled for a Pico on a Windows PC there are some requirements that are atypical for most Windows users, this note will explain some of the ways to get around the deficiencies of Windows when it comes to developing for the Pico.
+
+##### The Problem
+
+As Fidelio is part of a hardware security device it requires a cryptographically secure CERTIFICATE as part of it's functioning (something like how HTTPS works but even more secure). This certificate is part of the security system Fidelio uses and is, itself, used by Fidelio to create further certificates required to make Fidelio a safe system to use.
+
+The creation of a certificate requires a few utilities usually only found on Linux systems.
+
+While we could supply a default certificate this does create a potential security issue when creating a secure device so the decision was made to rely on the user creating their own certificate.
+
+##### The Solution(s)
+
+Fidelio requires access to recent versions of the openssl, sed and xxd command-line utilities
+
+The most obvious way to obtain these programs is by installing WSL, another way is to install Msys2. Both these methods will allow a Linux-like experience (but are beyond the scope of this note and left to the reader to research if they desire)
+
+##### Windows Native
+
+A slightly more complex, but having the advantage that it will work directly under Windows, method is to download Windows native versions of the three utilities required and making sure they are available from the command line.
+
+###### openssl
+
+There are many options at https://wiki.openssl.org/index.php/Binaries choose one of the "OpenSSL for Windows" versions (I chose the firedeamon one) and install it. Depending on the installer you use if you see the option to add OpenSSL to your path make sure you do that, otherwise you will need to manually add the installation directory to your path
+
+###### sed
+
+Get the installer (the one with setup in it's name) from https://sourceforge.net/projects/gnuwin32/files/sed/ then use setup to install the program.
+
+You will need to manually add the installation directory to your path
+
+###### xxd
+
+Get the zip from https://sourceforge.net/projects/xxd-for-windows/ Use your favourite UnZipping utility to extract the contents somewhere on your drive. You will need to manually add the location where sed.exe is to your path (I have a directory called C:\utils specifically for stuff like this)
+
+###### Test
+
+To make sure the above utilities are installed correctly open a command prompt and enter the following commands....
+
+openssl -h
+sed -h
+xxd -h
+
+All three should display some usage information. If they don't then you've most likely not added them to your path correctly
+
+###### Create your certificate
+
+Once you're happy everything above works open a command prompt and change to the Fidelio top-level directory
+
+Now type ...
+
+.\makecert.bat
+
+This should create a bunch of files (you can ignore) and also create src/cert.c (which is vitally important)
+
+You can personalise the certificate makecert creates by using a text editor (or using in VSCode?) to alter the file attestation-cert.conf. The default entries in the supplied version are largely nonsense so you might want to make them more relevant to you. Simply alter the entries after the equals (=) on any line you want to change to better suit your liking
+

--- a/WINDOWS.md
+++ b/WINDOWS.md
@@ -1,8 +1,8 @@
-### Windows Quirks
+# Windows Quirks
 
 While Fidelio can be compiled for a Pico on a Windows PC there are some requirements that are atypical for most Windows users, this note will explain some of the ways to get around the deficiencies of Windows when it comes to developing for the Pico.
 
-##### The Problem
+### The Problem
 
 As Fidelio is part of a hardware security device it requires a cryptographically secure CERTIFICATE as part of it's functioning (something like how HTTPS works but even more secure). This certificate is part of the security system Fidelio uses and is, itself, used by Fidelio to create further certificates required to make Fidelio a safe system to use.
 
@@ -10,31 +10,31 @@ The creation of a certificate requires a few utilities usually only found on Lin
 
 While we could supply a default certificate this does create a potential security issue when creating a secure device so the decision was made to rely on the user creating their own certificate.
 
-##### The Solution(s)
+### The Solution(s)
 
 Fidelio requires access to recent versions of the openssl, sed and xxd command-line utilities
 
 The most obvious way to obtain these programs is by installing WSL, another way is to install Msys2. Both these methods will allow a Linux-like experience (but are beyond the scope of this note and left to the reader to research if they desire)
 
-##### Windows Native
+### Windows Native
 
 A slightly more complex, but having the advantage that it will work directly under Windows, method is to download Windows native versions of the three utilities required and making sure they are available from the command line.
 
-###### openssl
+#### openssl
 
 There are many options at https://wiki.openssl.org/index.php/Binaries choose one of the "OpenSSL for Windows" versions (I chose the firedeamon one) and install it. Depending on the installer you use if you see the option to add OpenSSL to your path make sure you do that, otherwise you will need to manually add the installation directory to your path
 
-###### sed
+#### sed
 
 Get the installer (the one with setup in it's name) from https://sourceforge.net/projects/gnuwin32/files/sed/ then use setup to install the program.
 
 You will need to manually add the installation directory to your path
 
-###### xxd
+#### xxd
 
 Get the zip from https://sourceforge.net/projects/xxd-for-windows/ Use your favourite UnZipping utility to extract the contents somewhere on your drive. You will need to manually add the location where sed.exe is to your path (I have a directory called C:\utils specifically for stuff like this)
 
-###### Test
+#### Test
 
 To make sure the above utilities are installed correctly open a command prompt and enter the following commands....
 
@@ -44,7 +44,7 @@ xxd -h
 
 All three should display some usage information. If they don't then you've most likely not added them to your path correctly
 
-###### Create your certificate
+#### Create your certificate
 
 Once you're happy everything above works open a command prompt and change to the Fidelio top-level directory
 

--- a/mkcert.bat
+++ b/mkcert.bat
@@ -1,0 +1,12 @@
+openssl req -newkey ec -pkeyopt ec_paramgen_curve:"P-256" -keyout cert-master-key.pem -out cert-att.csr -sha256 -nodes -config attestation-cert.conf
+
+openssl x509 -req -in cert-att.csr -signkey cert-master-key.pem -out cert-att.pem -sha256 -days 3650 -extfile attestation-cert.conf -extensions v3_req
+
+openssl x509 -in cert-att.pem -out cert-att.der -outform der
+openssl ec -in cert-master-key.pem -out cert-master-key.der -outform der -conv_form uncompressed
+
+
+del src\cert.c
+xxd -i cert-att.der | sed -e "s/unsigned/const unsigned/g" >> src/cert.c
+xxd -i cert-master-key.der | sed -e "s/unsigned/const unsigned/g" >> src/cert.c
+

--- a/mkcert.sh
+++ b/mkcert.sh
@@ -1,9 +1,6 @@
-openssl req -newkey ec -pkeyopt ec_paramgen_curve:"P-256" -keyout cert-master-key.pem \
-    -out cert-att.csr -sha256 -nodes \
-    -config attestation-cert.conf
+openssl req -newkey ec -pkeyopt ec_paramgen_curve:"P-256" -keyout cert-master-key.pem -out cert-att.csr -sha256 -nodes -config attestation-cert.conf
 
-openssl x509 -req -in cert-att.csr -signkey cert-master-key.pem -out cert-att.pem -sha256 -days 3650 \
-    -extfile attestation-cert.conf -extensions v3_req
+openssl x509 -req -in cert-att.csr -signkey cert-master-key.pem -out cert-att.pem -sha256 -days 3650 -extfile attestation-cert.conf -extensions v3_req
 
 openssl x509 -in cert-att.pem -out cert-att.der -outform der
 openssl ec -in cert-master-key.pem -out cert-master-key.der -outform der -conv_form uncompressed

--- a/src/fidelio.c
+++ b/src/fidelio.c
@@ -46,10 +46,13 @@ void system_boot(void)
     rc = u2f_led_init();
     hard_assert(rc == PICO_OK);
 
+	/* If using BOOTSEL don't set the PRESENCE_BUTTON */
+	#ifndef USE_PRESENCE_BUTTON
     gpio_init(PRESENCE_BUTTON);
     gpio_set_dir(PRESENCE_BUTTON, GPIO_IN);
     gpio_pull_up(PRESENCE_BUTTON);
-
+	#endif
+	
     /* Momentarily blink led on startup - functioning indicator */
     u2f_set_led(1);
     sleep_ms(250);

--- a/src/fidelio.c
+++ b/src/fidelio.c
@@ -31,6 +31,7 @@
 #include "user_settings.h"
 #include "wolfssl/wolfcrypt/settings.h"
 #include "hardware/clocks.h"
+#include "led.h" 
     
 extern void u2f_init(void);
 
@@ -40,19 +41,23 @@ void system_boot(void)
     set_sys_clock_48mhz();
     
     /* Setting GPIOs for Led + Button */
-    gpio_init(U2F_LED);
-    gpio_set_dir(U2F_LED, GPIO_OUT);
+    int rc = u2f_led_init();
+    hard_assert(rc == PICO_OK);
 
     gpio_init(PRESENCE_BUTTON);
     gpio_set_dir(PRESENCE_BUTTON, GPIO_IN);
     gpio_pull_up(PRESENCE_BUTTON);
+
+    /* Momentarily blink led on startup - functioning indicator */
+    u2f_set_led(1);
+    sleep_ms(250);
+    u2f_set_led(0);
 
     /* Initializing U2F parser */
     u2f_init();
 
     /* Initializing TinyUSB device */
     tusb_init();
-
 }
 
 int main(void) {

--- a/src/fidelio.c
+++ b/src/fidelio.c
@@ -37,11 +37,13 @@ extern void u2f_init(void);
 
 void system_boot(void)
 {
+	int rc;
+	
     /* Setting system clock */
     set_sys_clock_48mhz();
     
     /* Setting GPIOs for Led + Button */
-    int rc = u2f_led_init();
+    rc = u2f_led_init();
     hard_assert(rc == PICO_OK);
 
     gpio_init(PRESENCE_BUTTON);

--- a/src/led.c
+++ b/src/led.c
@@ -1,6 +1,6 @@
 /* Fidelio
  *
- * (c) 2023 Peardox
+ * (c) 2023 Daniele Lacamera <root@danielinux.net>
  *
  *
  * Fidelio is free software; you can redistribute it and/or modify

--- a/src/led.c
+++ b/src/led.c
@@ -20,36 +20,39 @@
  */
 
 #include "led.h"
-// Pico W devices use a GPIO on the WIFI chip for the LED,
-// so when building for Pico W, CYW43_WL_GPIO_LED_PIN will be defined
+/* Pico W devices use a GPIO on the WIFI chip for the LED,
+ * so when building for Pico W, CYW43_WL_GPIO_LED_PIN will be defined
+ */
+
 #ifdef CYW43_WL_GPIO_LED_PIN
 #include "pico/cyw43_arch.h"
 #include "pico/cyw43_driver.h"
 #include "hardware/clocks.h"
 #endif
 
-// Perform initialisation
+/* Perform initialization */
 int u2f_led_init(void) {
 #ifndef CYW43_WL_GPIO_LED_PIN
-    // A device like Pico that uses a GPIO for the LED will define PICO_DEFAULT_LED_PIN
-    // so we can use normal GPIO functionality to turn the led on and off
-    gpio_init(PICO_DEFAULT_LED_PIN);
-    gpio_set_dir(PICO_DEFAULT_LED_PIN, GPIO_OUT);
+    /* A device like Pico that uses a GPIO for the LED will define U2F_LED
+     * so we can use normal GPIO functionality to turn the led on and off  
+	 */
+    gpio_init(U2F_LED);
+    gpio_set_dir(U2F_LED, GPIO_OUT);
     return PICO_OK;
 #else
-    // For Pico W devices we need to initialise the driver etc
+    /* For Pico W devices we need to initialize the driver etc */
     cyw43_set_pio_clock_divisor(1, 0);
     return cyw43_arch_init();
 #endif
 }
 
-// Turn the led on or off
+/* Turn the led on or off */
 void u2f_set_led(bool led_on) {
 #ifndef CYW43_WL_GPIO_LED_PIN
-    // Just set the GPIO on or off
-    gpio_put(PICO_DEFAULT_LED_PIN, led_on);
+    /* Just set the GPIO on or off */
+    gpio_put(U2F_LED, led_on);
 #else
-    // Ask the wifi "driver" to set the GPIO on or off
+    /* Ask the wifi "driver" to set the GPIO on or off */
     cyw43_arch_gpio_put(CYW43_WL_GPIO_LED_PIN, led_on);
 #endif
 }

--- a/src/led.c
+++ b/src/led.c
@@ -1,0 +1,56 @@
+/* Fidelio
+ *
+ * (c) 2023 Peardox
+ *
+ *
+ * Fidelio is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * Fidelio is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1335, USA
+ *
+ */
+
+#include "led.h"
+// Pico W devices use a GPIO on the WIFI chip for the LED,
+// so when building for Pico W, CYW43_WL_GPIO_LED_PIN will be defined
+#ifdef CYW43_WL_GPIO_LED_PIN
+#include "pico/cyw43_arch.h"
+#include "pico/cyw43_driver.h"
+#include "hardware/clocks.h"
+#endif
+
+// Perform initialisation
+int u2f_led_init(void) {
+#ifndef CYW43_WL_GPIO_LED_PIN
+    // A device like Pico that uses a GPIO for the LED will define PICO_DEFAULT_LED_PIN
+    // so we can use normal GPIO functionality to turn the led on and off
+    gpio_init(PICO_DEFAULT_LED_PIN);
+    gpio_set_dir(PICO_DEFAULT_LED_PIN, GPIO_OUT);
+    return PICO_OK;
+#else
+    // For Pico W devices we need to initialise the driver etc
+    cyw43_set_pio_clock_divisor(1, 0);
+    return cyw43_arch_init();
+#endif
+}
+
+// Turn the led on or off
+void u2f_set_led(bool led_on) {
+#ifndef CYW43_WL_GPIO_LED_PIN
+    // Just set the GPIO on or off
+    gpio_put(PICO_DEFAULT_LED_PIN, led_on);
+#else
+    // Ask the wifi "driver" to set the GPIO on or off
+    cyw43_arch_gpio_put(CYW43_WL_GPIO_LED_PIN, led_on);
+#endif
+}
+

--- a/src/led.c
+++ b/src/led.c
@@ -20,6 +20,7 @@
  */
 
 #include "led.h"
+#include "pins.h"
 /* Pico W devices use a GPIO on the WIFI chip for the LED,
  * so when building for Pico W, CYW43_WL_GPIO_LED_PIN will be defined
  */

--- a/src/led.c
+++ b/src/led.c
@@ -33,12 +33,14 @@
 
 /* Perform initialization */
 int u2f_led_init(void) {
-#ifndef CYW43_WL_GPIO_LED_PIN
+#ifdef U2F_LED
+    #if (U2F_LED >= 0)
     /* A device like Pico that uses a GPIO for the LED will define U2F_LED
      * so we can use normal GPIO functionality to turn the led on and off  
 	 */
     gpio_init(U2F_LED);
     gpio_set_dir(U2F_LED, GPIO_OUT);
+    #endif
     return PICO_OK;
 #else
     /* For Pico W devices we need to initialize the driver etc */
@@ -49,12 +51,15 @@ int u2f_led_init(void) {
 
 /* Turn the led on or off */
 void u2f_set_led(bool led_on) {
-#ifndef CYW43_WL_GPIO_LED_PIN
+#ifdef U2F_LED
+    #if (U2F_LED >= 0)
     /* Just set the GPIO on or off */
     gpio_put(U2F_LED, led_on);
+    #endif
 #else
+    #ifdef CYW43_WL_GPIO_LED_PIN
     /* Ask the wifi "driver" to set the GPIO on or off */
     cyw43_arch_gpio_put(CYW43_WL_GPIO_LED_PIN, led_on);
+    #endif
 #endif
 }
-

--- a/src/led.h
+++ b/src/led.h
@@ -23,6 +23,8 @@
 
 #include "pico/stdlib.h"
 
+#define U2F_LED PICO_DEFAULT_LED_PIN
+
 int u2f_led_init(void);
 void u2f_set_led(bool led_on);
 

--- a/src/led.h
+++ b/src/led.h
@@ -23,8 +23,6 @@
 
 #include "pico/stdlib.h"
 
-#define U2F_LED PICO_DEFAULT_LED_PIN
-
 int u2f_led_init(void);
 void u2f_set_led(bool led_on);
 

--- a/src/led.h
+++ b/src/led.h
@@ -18,9 +18,12 @@
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1335, USA
  *
  */
-#ifndef BUTTON_H
-#define BUTTON_H
+#ifndef U2F_LED_H
+#define U2F_LED_H
 
-#define PRESENCE_BUTTON 15
+#include "pico/stdlib.h"
+
+int u2f_led_init(void);
+void u2f_set_led(bool led_on);
 
 #endif

--- a/src/pins.h
+++ b/src/pins.h
@@ -22,6 +22,8 @@
 #define BUTTON_H
 
 #define PRESENCE_BUTTON 15
+/* Allow for pull-up/pull-down */
+#define PRESENCE_PRESSED 0
 
     #if !defined(U2F_LED) && defined(PICO_DEFAULT_LED_PIN)
     #define U2F_LED PICO_DEFAULT_LED_PIN

--- a/src/pins.h
+++ b/src/pins.h
@@ -19,11 +19,12 @@
  *
  */
 #ifndef BUTTON_H
-    #define BUTTON_H
+#define BUTTON_H
 
-    #define PRESENCE_BUTTON 15
+#define PRESENCE_BUTTON 15
 
     #if !defined(U2F_LED) && defined(PICO_DEFAULT_LED_PIN)
     #define U2F_LED PICO_DEFAULT_LED_PIN
     #endif
+
 #endif

--- a/src/pins.h
+++ b/src/pins.h
@@ -23,4 +23,8 @@
 
 #define PRESENCE_BUTTON 15
 
+#ifndef U2F_LED
+#define U2F_LED PICO_DEFAULT_LED_PIN
+#endif
+
 #endif

--- a/src/pins.h
+++ b/src/pins.h
@@ -19,12 +19,11 @@
  *
  */
 #ifndef BUTTON_H
-#define BUTTON_H
+    #define BUTTON_H
 
-#define PRESENCE_BUTTON 15
+    #define PRESENCE_BUTTON 15
 
-#ifndef U2F_LED
-#define U2F_LED PICO_DEFAULT_LED_PIN
-#endif
-
+    #if !defined(U2F_LED) && defined(PICO_DEFAULT_LED_PIN)
+    #define U2F_LED PICO_DEFAULT_LED_PIN
+    #endif
 #endif

--- a/src/presence.c
+++ b/src/presence.c
@@ -1,0 +1,87 @@
+/* Fidelio
+ *
+ * (c) 2023 Daniele Lacamera <root@danielinux.net>
+ *
+ *
+ * Fidelio is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * Fidelio is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1335, USA
+ *
+ */
+
+#include "pico/stdlib.h"
+#include "hardware/gpio.h"
+#include "pins.h"
+
+#ifdef USE_BOOTSEL_BUTTON
+#include "hardware/sync.h"
+#include "hardware/structs/ioqspi.h"
+#include "hardware/structs/sio.h"
+
+bool get_bootsel_button_state(void);
+
+
+/* Code to check if the bootsel button is pressed
+ *
+ * Blatantly pinched from lib/tinyusb/hw/bsp/rp2040/family.c
+ */ 
+bool __no_inline_not_in_flash_func(_get_bootsel_button)(void) {
+  const uint CS_PIN_INDEX = 1;
+
+  /* Must disable interrupts, as interrupt handlers may be in flash, and we
+   * are about to temporarily disable flash access!
+   */
+  uint32_t flags = save_and_disable_interrupts();
+
+  /* Set chip select to Hi-Z */
+  hw_write_masked(&ioqspi_hw->io[CS_PIN_INDEX].ctrl,
+                  GPIO_OVERRIDE_LOW << IO_QSPI_GPIO_QSPI_SS_CTRL_OEOVER_LSB,
+                  IO_QSPI_GPIO_QSPI_SS_CTRL_OEOVER_BITS);
+
+  /* Note we can't call into any sleep functions in flash right now */
+  for (volatile int i = 0; i < 1000; ++i);
+
+  /* The HI GPIO registers in SIO can observe and control the 6 QSPI pins.
+   * Note the button pulls the pin *low* when pressed.
+   */
+  bool button_state = (sio_hw->gpio_hi_in & (1u << CS_PIN_INDEX));
+
+  /* Need to restore the state of chip select, else we are going to have a
+   * bad time when we return to code in flash!
+   */
+  hw_write_masked(&ioqspi_hw->io[CS_PIN_INDEX].ctrl,
+                  GPIO_OVERRIDE_NORMAL << IO_QSPI_GPIO_QSPI_SS_CTRL_OEOVER_LSB,
+                  IO_QSPI_GPIO_QSPI_SS_CTRL_OEOVER_BITS);
+
+  restore_interrupts(flags);
+
+  return button_state;
+}
+
+bool get_bootsel_button_state(void) {
+    return !_get_bootsel_button();
+}
+
+#endif
+
+bool get_presence(void) {
+#ifdef USE_BOOTSEL_BUTTON
+    return get_bootsel_button_state();
+#else
+    if (gpio_get(PRESENCE_BUTTON) == PRESENCE_PRESSED) {
+        return true;
+    } else {
+        return false;
+    }
+#endif
+}

--- a/src/presence.h
+++ b/src/presence.h
@@ -1,0 +1,27 @@
+/* Fidelio
+ *
+ * (c) 2023 Daniele Lacamera <root@danielinux.net>
+ *
+ *
+ * Fidelio is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * Fidelio is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1335, USA
+ *
+ */
+
+#ifndef PRESENCE_H
+#define PRESENCE_H
+
+bool get_presence(void);
+
+#endif

--- a/src/u2f.c
+++ b/src/u2f.c
@@ -644,6 +644,7 @@ int parse_u2fhid_packet(const uint8_t *data)
 /* SET_REPORT is called with ID=0 and Type=0 when receiving data
  * on the 'OUT' endpoint
  */
+
 void tud_hid_set_report_cb(uint8_t itf, uint8_t report_id, hid_report_type_t report_type, uint8_t const* buffer, uint16_t bufsize)
 {
     (void) itf;
@@ -668,7 +669,7 @@ uint16_t tud_hid_get_report_cb(uint8_t instance, uint8_t report_id, hid_report_t
   return 0;
 }
 
-void tud_hid_report_complete_cb(uint8_t instance, uint8_t const* report, uint16_t len)
+void tud_hid_report_complete_cb(uint8_t instance, const uint8_t *report, uint16_t len)
 {
     (void) instance;
     (void) len;

--- a/src/u2f.c
+++ b/src/u2f.c
@@ -669,7 +669,7 @@ uint16_t tud_hid_get_report_cb(uint8_t instance, uint8_t report_id, hid_report_t
   return 0;
 }
 
-void tud_hid_report_complete_cb(uint8_t instance, const uint8_t *report, uint16_t len)
+void tud_hid_report_complete_cb(uint8_t instance, uint8_t const* report, uint16_t len)
 {
     (void) instance;
     (void) len;

--- a/src/u2f.c
+++ b/src/u2f.c
@@ -34,6 +34,7 @@
 #include "cert.h"
 #include "pins.h"
 #include "led.h"
+#include "presence.h"
 
 
 #define PUBKEY_SZ 65
@@ -258,7 +259,7 @@ static uint16_t fido_register(struct u2f_raw_hdr *hdr, uint16_t len)
     u2f_set_led(1);
     while(1) {
         sleep_ms(2);
-        if (gpio_get(PRESENCE_BUTTON) == 0) {
+        if (get_presence()) {
             break;
         }
     }
@@ -407,7 +408,7 @@ static uint16_t fido_auth(struct u2f_raw_hdr *hdr, uint16_t len)
             u2f_set_led(1);
             while(1) {
                 sleep_ms(2);
-                if (gpio_get(PRESENCE_BUTTON) == 0) {
+                if (get_presence()) {
                     user_presence = 0x01;
                     break;
                 }

--- a/src/u2f.c
+++ b/src/u2f.c
@@ -33,6 +33,7 @@
 #include "wolfssl/wolfcrypt/hmac.h"
 #include "cert.h"
 #include "pins.h"
+#include "led.h"
 
 
 #define PUBKEY_SZ 65
@@ -66,7 +67,7 @@ static void flash_master_keygen(void)
 {
     WC_RNG rng;
     uint8_t mkey_buffer[4 + 32];
-    gpio_put(U2F_LED, 1);
+    u2f_set_led(1);
     wc_InitRng(&rng);
     wc_RNG_GenerateBlock(&rng, mkey_buffer, 32);
     flash_range_erase(FLASH_MKEY_OFF, FLASH_SECTOR_SIZE);
@@ -76,7 +77,7 @@ static void flash_master_keygen(void)
     flash_range_program(FLASH_MKEY_OFF, (void *)&master_magic, 4);
     flash_range_program(FLASH_MKEY_OFF + 4, mkey_buffer, 32);
     wc_FreeRng(&rng);
-    gpio_put(U2F_LED, 0);
+    u2f_set_led(0);
 }
 
 static void U2F_Counter_up(void)
@@ -254,14 +255,14 @@ static uint16_t fido_register(struct u2f_raw_hdr *hdr, uint16_t len)
     (void)len;
 
 
-    gpio_put(U2F_LED, 1);
+    u2f_set_led(1);
     while(1) {
         sleep_ms(2);
         if (gpio_get(PRESENCE_BUTTON) == 0) {
             break;
         }
     }
-    gpio_put(U2F_LED, 0);
+    u2f_set_led(0);
 
     /* Initialize wolfCrypt objects */
     if (wc_InitRng(&rng) != 0)
@@ -403,7 +404,7 @@ static uint16_t fido_auth(struct u2f_raw_hdr *hdr, uint16_t len)
         case 0x08: /* Sign with no presence */
             break;
         case 0x03:
-            gpio_put(U2F_LED, 1);
+            u2f_set_led(1);
             while(1) {
                 sleep_ms(2);
                 if (gpio_get(PRESENCE_BUTTON) == 0) {
@@ -411,7 +412,7 @@ static uint16_t fido_auth(struct u2f_raw_hdr *hdr, uint16_t len)
                     break;
                 }
             }
-            gpio_put(U2F_LED, 0);
+            u2f_set_led(0);
             break;
         default:
             return EWRONGDATA;


### PR DESCRIPTION
This (somwhat longer than desired) version enables compatibility with pico, pico w and pico 2

Basically the LED stuff is split out and calls are made rather than directly accessing pins

This version decides what to build based in the CMakeLists.txt - and command-line  e.g. -DPICO_BOARD=pico_w will build for a W

Specifically PICO_DEFAULT_LED_PIN doesn't work on a Pico W as it's pin is via the CYW43

I had problems getting pico2 to run from command but that's the toolchain I was checking with. When build via VSCode it does fine with pico2

It also appears as you've _MAY HAVE_ a specific SDK - had problems until I repaced pico-sdk with a fresh one (that family_example stuff was driving me crazy - appears to be old stuff)

Checked resulting u2f's against all devices (pico, pico w, + pico 2)